### PR TITLE
Change publish step to write docker image to sslhep repo

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Build DID-Finder Image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: gordonwatts/servicex-did-finder-cernopendata:${{ steps.extract_tag_name.outputs.imagetag }}
+        name: sslhep/servicex-did-finder-cernopendata:${{ steps.extract_tag_name.outputs.imagetag }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         tag: "${GITHUB_REF##*/}"


### PR DESCRIPTION
# Problem
The GHA pipeline publishes to Gordon's DockerHub repo

# Approach
Change the publish step and update the secrets