### PR TITLE
OpenData Test Fixes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,8 +9,41 @@ on:
   pull_request:
 
 jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install poetry
+      uses: Gr1N/setup-poetry@v4
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        poetry install
+        pip list
+
+    - name: Lint with Flake8
+      run: |
+        poetry run flake8
+    - name: Test with pytest
+      run: |
+        poetry run coverage run -m --source=src pytest tests
+        poetry run coverage xml
+
   publish:
     runs-on: ubuntu-latest
+    needs: test
+    
     steps:
     - uses: actions/checkout@master
 

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ dmypy.json
 
 # Requirements should always be locally generated
 requirements.txt
+poetry.lock

--- a/poetry.lock
+++ b/poetry.lock
@@ -1029,6 +1029,20 @@ checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.15.1"
+description = "Pytest support for asyncio."
+category = "dev"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["coverage", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
@@ -1324,7 +1338,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "b02ab4f34ae24c19fb9bad767440e9583ae4471ff7b8df55cede3f3d61aeda5d"
+content-hash = "3ee6fd31fa2138e192256a0d054445adf04798baec96a2f9db2f8a3e725a0e0b"
 
 [metadata.files]
 aiohttp = [
@@ -2016,6 +2030,10 @@ pyrsistent = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.15.1.tar.gz", hash = "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f"},
+    {file = "pytest_asyncio-0.15.1-py3-none-any.whl", hash = "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -224,6 +224,17 @@ pyyaml = "*"
 test = ["pathlib"]
 
 [[package]]
+name = "coverage"
+version = "5.5"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 name = "cycler"
 version = "0.10.0"
 description = "Composable style cycles"
@@ -1338,7 +1349,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "3ee6fd31fa2138e192256a0d054445adf04798baec96a2f9db2f8a3e725a0e0b"
+content-hash = "7a4f2bcb1575be7d2828bc55864b19d5242426f1051730ea7047b15546c1fb32"
 
 [metadata.files]
 aiohttp = [
@@ -1557,6 +1568,60 @@ configparser = [
 confuse = [
     {file = "confuse-1.3.0-py2.py3-none-any.whl", hash = "sha256:0600af9544e6e82a01e6a4225fb33c566edbd0df919b576e3bc9643e501275f9"},
     {file = "confuse-1.3.0.tar.gz", hash = "sha256:f68a1c61fdb175b88e7a1466277c5b62bd039b722c1bbb72d42df24253d32b1f"},
+]
+coverage = [
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 cycler = [
     {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ jupyterlab = "^3.0.16"
 func-adl-servicex = "^1.0.4"
 matplotlib = "^3.4.2"
 pytest-asyncio = "^0.15.1"
+coverage = "^5.5"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ flake8 = "^3.9.1"
 jupyterlab = "^3.0.16"
 func-adl-servicex = "^1.0.4"
 matplotlib = "^3.4.2"
+pytest-asyncio = "^0.15.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/servicex_did_finder_cernopendata/did_finder.py
+++ b/src/servicex_did_finder_cernopendata/did_finder.py
@@ -48,12 +48,13 @@ async def find_files(did_name: str,
             uri = line.strip()
             if not uri.startswith('root://'):
                 non_root_uri = True
-            yield {
-                'file_path': uri,
-                'adler32': 0,  # No clue
-                'file_size': 0,  # Size in bytes if known
-                'file_events': 0,  # Number of events if known
-            }
+            else:
+                yield {
+                    'file_path': uri,
+                    'adler32': 0,  # No clue
+                    'file_size': 0,  # Size in bytes if known
+                    'file_events': 0,  # Number of events if known
+                }
 
         # Next, sort out the errors (if there are any)
         p.wait()

--- a/src/servicex_did_finder_cernopendata/did_finder.py
+++ b/src/servicex_did_finder_cernopendata/did_finder.py
@@ -7,7 +7,10 @@ from servicex_did_finder_lib import start_did_finder
 __log = logging.getLogger(__name__)
 
 
-async def find_files(did_name: str, info: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+async def find_files(did_name: str,
+                     info: Dict[str, Any],
+                     command: str = 'cernopendata-client'
+                     ) -> AsyncGenerator[Dict[str, Any], None]:
     '''For each incoming did name, generate a list of files that ServiceX can
     process
 
@@ -19,6 +22,9 @@ async def find_files(did_name: str, info: Dict[str, Any]) -> AsyncGenerator[Dict
 
     Args:
         did_name (str): Dataset name
+        into (Dict[str, Any]): Information bag, mainly has the `request-id` which is
+                               used to track error mesages accross logs.
+        command (str): Command to execute to get the did information. Used only for testing.
 
     Returns:
         AsyncGenerator[Dict[str, any], None]: yield each file
@@ -28,12 +34,13 @@ async def find_files(did_name: str, info: Dict[str, Any]) -> AsyncGenerator[Dict
     if not did_name.isnumeric():
         raise Exception('CERNOpenData can only work with dataset numbers as names (e.g. 1507)')
 
-    cmd = f'cernopendata-client get-file-locations --protocol xrootd --recid {did_name}'.split(' ')
+    cmd = f'{command} get-file-locations --protocol xrootd --recid {did_name}'.split(' ')
     print(cmd)
 
     with Popen(cmd, stdout=PIPE, stderr=STDOUT, bufsize=1,
                universal_newlines=1) as p:  # type: ignore
 
+        assert p.stdout is not None
         for line in p.stdout:
             assert isinstance(line, str)
             uri = line.strip()

--- a/src/servicex_did_finder_cernopendata/did_finder.py
+++ b/src/servicex_did_finder_cernopendata/did_finder.py
@@ -38,7 +38,7 @@ async def find_files(did_name: str, info: Dict[str, Any]) -> AsyncGenerator[Dict
             assert isinstance(line, str)
             uri = line.strip()
             if not uri.startswith('root://'):
-                raise Exception(f'CMSOpenData: Opendata record returned a non-xrootd url: {uri}')
+                raise Exception(f'CMSOpenData: Opendata record returned a non-xrootd url: "{uri}"')
             yield {
                 'file_path': uri,
                 'adler32': 0,  # No clue

--- a/tests/test_servicex_did_finder_cernopendata.py
+++ b/tests/test_servicex_did_finder_cernopendata.py
@@ -1,5 +1,3 @@
 from servicex_did_finder_cernopendata import __version__
 
 
-def test_version():
-    assert __version__ == '0.1.0'

--- a/tests/test_servicex_did_finder_cernopendata.py
+++ b/tests/test_servicex_did_finder_cernopendata.py
@@ -1,3 +1,52 @@
-from servicex_did_finder_cernopendata import __version__
+from typing import Iterator
+import pytest
+from src.servicex_did_finder_cernopendata.did_finder import find_files
+from contextlib import contextmanager
+from tempfile import TemporaryDirectory
+from pathlib import Path
 
 
+@contextmanager
+def command_for_files_back(url: str) -> Iterator[Path]:
+    with TemporaryDirectory() as tdir:
+        path = Path(tdir) / 'runner.py'
+        with path.open('w') as tfp:
+            tfp.write(f'print ("{url}")')
+            tfp.write('\n')
+
+        yield path
+
+
+@pytest.mark.asyncio
+async def test_working_call():
+    with command_for_files_back('root://root.idiot.it/dude') as script_name:
+        iter = find_files('1507',
+                          {'request-id': '112233'},
+                          command=f'python {script_name}'
+                          )
+        files = [f async for f in iter]
+
+        assert len(files) == 1
+        assert isinstance(files[0], dict)
+        assert files[0]['file_path'] == 'root://root.idiot.it/dude'
+
+
+@pytest.mark.asyncio
+async def test_non_root_return():
+    with command_for_files_back('http://root.idiot.it/dude') as script_name:
+        iter = find_files('1507',
+                          {'request-id': '112233'},
+                          command=f'python {script_name}'
+                          )
+        with pytest.raises(Exception) as e:
+            [f async for f in iter]
+
+        assert 'non-xrootd' in str(e)
+
+
+@pytest.mark.asyncio
+async def test_invalid_did_alpha():
+    with pytest.raises(Exception) as e:
+        [f async for f in find_files('dude', {'request-id': '112233'})]
+
+    assert 'number' in str(e)


### PR DESCRIPTION
Series of issues discovered while running on the CMS OPenData demos. See https://github.com/ssl-hep/ServiceX/issues/320 for an outline of work on this PR

* Make the error message for a blank line more clear by adding a quote
* Properly capture output and dump it when process exits
* Only dump malformed url error message if everything else looks good
* Added CI to track changes and regressions